### PR TITLE
Proguard Config

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,7 +32,8 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,17 +1,19 @@
-# Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in /usr/local/Cellar/android-sdk/24.4.1/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+####--------Retrofit------####
+-dontnote retrofit2.Platform
+-dontwarn retrofit2.Platform$Java8
+-keepattributes Signature
+-keepattributes Exceptions
 
-# Add any project specific keep options here:
+####--------Okio----------####
+-dontwarn okio.**
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+####--------Gson----------####
+-keepattributes Signature
+-keepattributes *Annotation*
+-keep class sun.misc.Unsafe { *; }
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer
+
+####-----Model classes---####
+-keep class io.mvpstarter.sample.data.model.** { *; }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jul 24 23:38:52 IST 2017
+#Sat Jul 29 12:33:12 IST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-rc-1-all.zip


### PR DESCRIPTION
- Contains proguard exclusions for model classes, retrofit, okio and gson.

This resolves https://github.com/androidstarters/kotlin-android-starter/issues/11